### PR TITLE
Add a delete call to preserve move behavior

### DIFF
--- a/cmtc/src/main/scala/coursemgmt/client/command/Install.scala
+++ b/cmtc/src/main/scala/coursemgmt/client/command/Install.scala
@@ -82,6 +82,7 @@ object Install:
             (targetFolder.exists, forceDelete) match {
               case (false, _) | (true, true) =>
                 sbtio.copyDirectory(tmpDir / project, targetFolder)
+                sbtio.delete(tmpDir / project)
                 if (deleteZipAfterInstall) {
                   sbtio.delete(zipFile.value)
                 }


### PR DESCRIPTION
Hi,

I looked at the changes you did in https://github.com/scalacenter/course-management-tools/pull/301/commits/b9c29d188b1878ac8d80b2ee016e88b2653e96b6 and noticed that these do not behave in the same way as before.

To mimic a **move** the directory needs to be **deleted** after the `copyDirectory`-call.

Linked Issue: https://github.com/scalacenter/course-management-tools/issues/297
